### PR TITLE
prevent shell variable expansion

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -38,7 +38,11 @@ def getoutput(command, stripped=True):
 def quote(stringtoquote):
     stringtoquote = stringtoquote.replace('\"', "'")  # replace " with '
     quotedstring = '\"' + stringtoquote + '\"'
-    return quotedstring
+    return escapeShellVariableExpansion(quotedstring)
+
+
+def escapeShellVariableExpansion(comment):
+    return comment.replace('$', '"\\$"')
 
 
 def shout_command_to_log(command, outputfile=None):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -30,3 +30,7 @@ class ShellTest(unittest.TestCase):
     def testSetNoEncoding_ShouldBeNone(self):
         shell.setencoding("")
         self.assertIsNone(shell.encoding)
+
+    def testEscapeShellVariableExpansion(self):
+        self.assertEqual('my simple comment', shell.escapeShellVariableExpansion('my simple comment'))
+        self.assertEqual('my simple "\$"variable comment', shell.escapeShellVariableExpansion('my simple $variable comment'))


### PR DESCRIPTION
Fixes #97.

As stated in the issue #97, a live test from `hub.jazz.net` preserved the `$variable` in the commit comment.
