### PR TITLE
Attempt RTC login with and without quotes. Exit if login failed.

### DIFF
--- a/rtcFunctions.py
+++ b/rtcFunctions.py
@@ -11,6 +11,8 @@ from configuration import ComponentBaseLineEntry
 from gitFunctions import Commiter, Differ
 
 
+loginCredentialsCommand = "-u '%s' -P '%s'"
+
 class RTCInitializer:
     @staticmethod
     def initialize():
@@ -28,7 +30,15 @@ class RTCLogin:
     @staticmethod
     def loginandcollectstreamuuid():
         config = configuration.get()
-        shell.execute("%s login -r %s -u '%s' -P '%s'" % (config.scmcommand, config.repo, config.user, config.password))
+        loginHeaderCommand = "%s login -r %s "
+        exitcode = shell.execute((loginHeaderCommand + loginCredentialsCommand) % (config.scmcommand, config.repo, config.user, config.password))
+        if exitcode is not 0:
+            shouter.shout("Login failed. Trying again without quotes.")
+            global loginCredentialsCommand
+            loginCredentialsCommand = "-u %s -P %s"
+            exitcode = shell.execute((loginHeaderCommand + loginCredentialsCommand) % (config.scmcommand, config.repo, config.user, config.password))
+            if exitcode is not 0:
+                sys.exit("Login failed. Please check your connection and credentials.")
         config.collectstreamuuids()
 
     @staticmethod
@@ -187,7 +197,7 @@ class ImportHandler:
         for entry in componentbaselinesentries:
             shouter.shout("Determine initial baseline of " + entry.componentname)
             # use always scm, lscm fails when specifying maximum over 10k
-            command = "scm --show-alias n --show-uuid y list baselines --components %s -r %s -u %s -P '%s' -m 20000" % \
+            command = ("scm --show-alias n --show-uuid y list baselines --components %s -r %s " + loginCredentialsCommand + " -m 20000") % \
                       (entry.component, config.repo, config.user, config.password)
             baselineslines = shell.getoutput(command)
             baselineslines.reverse()  # reverse to have earliest baseline on top

--- a/rtcFunctions.py
+++ b/rtcFunctions.py
@@ -29,12 +29,12 @@ class RTCInitializer:
 class RTCLogin:
     @staticmethod
     def loginandcollectstreamuuid():
+        global loginCredentialsCommand
         config = configuration.get()
         loginHeaderCommand = "%s login -r %s "
         exitcode = shell.execute((loginHeaderCommand + loginCredentialsCommand) % (config.scmcommand, config.repo, config.user, config.password))
         if exitcode is not 0:
             shouter.shout("Login failed. Trying again without quotes.")
-            global loginCredentialsCommand
             loginCredentialsCommand = "-u %s -P %s"
             exitcode = shell.execute((loginHeaderCommand + loginCredentialsCommand) % (config.scmcommand, config.repo, config.user, config.password))
             if exitcode is not 0:


### PR DESCRIPTION
Added new feature to exit the script if login fails. It certainly helped me when I was trying to figure out why the script wasn't working since the failed login message got buried near the top of all the messages.

Also, none of my environments worked when connecting if the username/password was enclosed in quotes. It worked fine if I removed them. I'm guessing most people don't have this issue or else it would've been removed in your code, so I made the option to try to login with and without it. Of course, I can make a different commit that doesn't use quotes at all if this is a bit too much.