### PR TITLE
Ensure the correct branch is checked out before doing any changes

### DIFF
--- a/migration.py
+++ b/migration.py
@@ -44,6 +44,7 @@ def resume():
     if config.previousstreamname:
         prepare()
     else:
+        Commiter.branch(config.streamname)
         WorkspaceHandler().load()
 
 


### PR DESCRIPTION
That's it.

If you have multiple streams in one Git Repo and load before you switch branches, the later switch will fail because you will have changes that would be overwritten.