### PR TITLE
Allow using a connection with cached password

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -10,6 +10,7 @@ config = None
 configfile = None
 user = None
 password = None
+stored = None
 
 
 def read(configname=None):
@@ -24,10 +25,10 @@ def read(configname=None):
     migrationsection = parsedconfig[migrationsectionname]
     miscsectionname = 'Miscellaneous'
     global user
-    if not user:
+    if not user and not stored:
         user = generalsection['User']
     global password
-    if not password:
+    if not password and not stored:
         password = generalsection['Password']
     repositoryurl = generalsection['Repo']
     scmcommand = generalsection.get('ScmCommand', "lscm")
@@ -55,7 +56,7 @@ def read(configname=None):
     gitattributesproperty = parsedconfig.get(migrationsectionname, 'Gitattributes', fallback='')
     gitattributes = parsesplittedproperty(gitattributesproperty)
 
-    configbuilder = Builder().setuser(user).setpassword(password).setrepourl(repositoryurl).setscmcommand(scmcommand)
+    configbuilder = Builder().setuser(user).setpassword(password).setstored(stored).setrepourl(repositoryurl).setscmcommand(scmcommand)
     configbuilder.setworkspace(workspace).setgitreponame(gitreponame).setrootfolder(os.getcwd())
     configbuilder.setuseexistingworkspace(useexistingworkspace).setuseprovidedhistory(useprovidedhistory)
     configbuilder.setuseautomaticconflictresolution(useautomaticconflictresolution)
@@ -92,6 +93,11 @@ def setPassword(newpassword):
     password = newpassword
 
 
+def setStored(newstored):
+    global stored
+    stored = newstored
+
+
 def getinitialcomponentbaselines(definedbaselines):
     initialcomponentbaselines = []
     if definedbaselines:
@@ -120,6 +126,7 @@ class Builder:
     def __init__(self):
         self.user = ""
         self.password = ""
+        self.stored = False
         self.repourl = ""
         self.scmcommand = "lscm"
         self.workspace = ""
@@ -148,6 +155,10 @@ class Builder:
 
     def setpassword(self, password):
         self.password = password
+        return self
+
+    def setstored(self, stored):
+        self.stored = stored
         return self
 
     def setrepourl(self, repourl):
@@ -232,7 +243,7 @@ class Builder:
         return stringwithbooleanexpression == "True"
 
     def build(self):
-        return ConfigObject(self.user, self.password, self.repourl, self.scmcommand, self.workspace,
+        return ConfigObject(self.user, self.password, self.stored, self.repourl, self.scmcommand, self.workspace,
                             self.useexistingworkspace, self.workdirectory, self.initialcomponentbaselines,
                             self.streamname, self.gitreponame, self.useprovidedhistory,
                             self.useautomaticconflictresolution, self.maxchangesetstoaccepttogether, self.clonedgitreponame, self.rootFolder,
@@ -241,12 +252,13 @@ class Builder:
 
 
 class ConfigObject:
-    def __init__(self, user, password, repourl, scmcommand, workspace, useexistingworkspace, workdirectory,
+    def __init__(self, user, password, stored, repourl, scmcommand, workspace, useexistingworkspace, workdirectory,
                  initialcomponentbaselines, streamname, gitreponame, useprovidedhistory,
                  useautomaticconflictresolution, maxchangesetstoaccepttogether, clonedgitreponame, rootfolder, previousstreamname,
                  ignorefileextensions, ignoredirectories, includecomponentroots, commitmessageprefix, gitattributes):
         self.user = user
         self.password = password
+        self.stored = stored
         self.repo = repourl
         self.scmcommand = scmcommand
         self.workspace = workspace

--- a/migration.py
+++ b/migration.py
@@ -142,10 +142,12 @@ def parsecommandline():
                         default=configfiledefault)
     parser.add_argument('-u', '--user', metavar='user', dest='user', help='RTC user', default=None)
     parser.add_argument('-p', '--password', metavar='password', dest='password', help='RTC password', default=None)
+    parser.add_argument('-s', '--stored', help='Use stored password for the repository connection', action='store_true')
     arguments = parser.parse_args()
     configuration.setconfigfile(arguments.configfile)
     configuration.setUser(arguments.user)
     configuration.setPassword(arguments.password)
+    configuration.setStored(arguments.stored)
 
 
 def validate():

--- a/rtcFunctions.py
+++ b/rtcFunctions.py
@@ -28,13 +28,15 @@ class RTCLogin:
     @staticmethod
     def loginandcollectstreamuuid():
         config = configuration.get()
-        shell.execute("%s login -r %s -u '%s' -P '%s'" % (config.scmcommand, config.repo, config.user, config.password))
+        if not config.stored:
+            shell.execute("%s login -r %s -u '%s' -P '%s'" % (config.scmcommand, config.repo, config.user, config.password))
         config.collectstreamuuids()
 
     @staticmethod
     def logout():
         config = configuration.get()
-        shell.execute("%s logout -r %s" % (config.scmcommand, config.repo))
+        if not config.stored:
+            shell.execute("%s logout -r %s" % (config.scmcommand, config.repo))
 
 
 class WorkspaceHandler:
@@ -187,8 +189,10 @@ class ImportHandler:
         for entry in componentbaselinesentries:
             shouter.shout("Determine initial baseline of " + entry.componentname)
             # use always scm, lscm fails when specifying maximum over 10k
-            command = "scm --show-alias n --show-uuid y list baselines --components %s -r %s -u %s -P '%s' -m 20000" % \
-                      (entry.component, config.repo, config.user, config.password)
+            command = "scm --show-alias n --show-uuid y list baselines --components %s -r %s -m 20000" % \
+                      (entry.component, config.repo)
+            if not config.stored:
+                command += "-u %s -P '%s'" % (config.user, config.password)
             baselineslines = shell.getoutput(command)
             baselineslines.reverse()  # reverse to have earliest baseline on top
 


### PR DESCRIPTION
This PR allows to pass a `-s/--stored` parameter to `migrate.py` to leverage an existing connection with cached password.
E.g. using `scm login -r https://example.org/ccm -u iamuser -c -n iamnickname` and then setting `General.Repo` to `iamnickname`